### PR TITLE
Feature/US-40

### DIFF
--- a/OngProject/Core/Business/AuthBusiness.cs
+++ b/OngProject/Core/Business/AuthBusiness.cs
@@ -89,6 +89,7 @@ namespace OngProject.Core.Business
             ClaimsIdentity claims = new ClaimsIdentity();
             claims.AddClaim(new Claim(ClaimTypes.Email, user.Email));
             claims.AddClaim(new Claim(ClaimTypes.Role, user.Roles.Name));
+            claims.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()));
 
             var tokenDescriptor = new SecurityTokenDescriptor
             {

--- a/OngProject/Middleware/PersistActionsRestrictionsMiddleware.cs
+++ b/OngProject/Middleware/PersistActionsRestrictionsMiddleware.cs
@@ -12,6 +12,7 @@ namespace OngProject.Middleware
         private readonly List<string> _restrictedRestMethods;
         private readonly List<string> _authorizedRoles;
         private readonly RequestDelegate _next;
+        private readonly string _roleUser;
 
         public PersistActionsRestrictionsMiddleware(RequestDelegate next)
         {
@@ -19,13 +20,13 @@ namespace OngProject.Middleware
 
             _authorizedRoles = new List<string> { "Administrador" };
             _restrictedRestMethods = new List<string> { "POST", "PUT", "PATCH", "DELETE" };
+            _roleUser = "Usuario";
         }
 
         public async Task InvokeAsync(HttpContext context)
         { 
             var isRestrictedAction = _restrictedRestMethods.Any(x => x == context.Request.Method);
             var isAuthRoute = context.Request.Path.StartsWithSegments("/Auth");
-
             var canAccessToRoute = isAuthRoute || !isRestrictedAction || userHasAuthorizedRole(context);
 
             if (!canAccessToRoute)
@@ -45,6 +46,56 @@ namespace OngProject.Middleware
             var userRole = identity.Claims.FirstOrDefault(x => x.Type == identity.RoleClaimType);
             
             return _authorizedRoles.Any(x => x == userRole.Value);
+        }
+
+        private async Task<bool> Ownership(HttpContext context, string route, string method)
+        {
+            var RouteProtected = context.Request.Path.StartsWithSegments(route) && context.Request.Method == method;
+
+            if (RouteProtected)
+            {
+                var canAccessToRoute = userHasAuthorizedRole(context) || userHasRole(context) && compareId(context);
+
+                if (canAccessToRoute)
+                {
+                    await _next.Invoke(context);
+                    return true;
+                }
+                if (!canAccessToRoute)
+                {
+                    context.Response.StatusCode = 403;
+                    return true;
+                }
+            }
+            return false;
+        }
+        private string getUserId(HttpContext context)
+        {
+            var identity = context.User.Identity as ClaimsIdentity;
+            var userId = context.User.Claims.ToArray()[2].Value;
+            return userId;
+        }
+
+        private bool compareId(HttpContext context)
+        {
+            var idParameter = context.Request.RouteValues["id"].ToString();
+            if (getUserId(context) == idParameter)
+                return true;
+            else return false;
+        }
+
+        private bool userHasRole(HttpContext context)
+        {
+            var identity = context.User.Identity as ClaimsIdentity;
+
+            if (identity == null || !identity.Claims.Any())
+                return false;
+
+            var userRole = identity.Claims.FirstOrDefault(x => x.Type == identity.RoleClaimType);
+
+            if (userRole.Value == _roleUser)
+                return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
Claim for to save id in token added in AuthBusiness.
Logic for protect endpoints that are only for current user added in PersistActionsRestrictionsMiddleware.

Tests done on endpoint /User delete method:

With a user id in the token different from the sent by parameter
![imagen](https://user-images.githubusercontent.com/63136194/172395253-28e8ea7d-b140-47ba-b176-3bf271618ff6.png)

With the same user id sent in the token and by parameter
![imagen](https://user-images.githubusercontent.com/63136194/172396152-e12de52e-2929-4e68-85d9-102eea0b5f59.png)

In database
![imagen](https://user-images.githubusercontent.com/63136194/172396609-1f06e882-857c-4444-8901-b518723c0f8b.png)


With a user id in the token of Admin role
![imagen](https://user-images.githubusercontent.com/63136194/172398469-5a1f844b-040e-481c-9d8b-62cf913ab07b.png)

The user id sent by parameter is different to user id in the token but this token have admin role
![imagen](https://user-images.githubusercontent.com/63136194/172398683-68b295d0-f30b-4dcc-9c46-b5f244a5102e.png)

In database
![imagen](https://user-images.githubusercontent.com/63136194/172398804-bad45716-d6af-4083-9678-2f5bc61d7b04.png)